### PR TITLE
Prep for GitHub pages

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -20,7 +20,7 @@
     {{content-for 'body'}}
 
     <script src="assets/vendor.js"></script>
-    <script src="assets/smallprint.js"></script>
+    <script src="assets/priv-o-matic.js"></script>
 
     {{content-for 'body-footer'}}
   </body>

--- a/app/index.html
+++ b/app/index.html
@@ -10,7 +10,7 @@
     {{content-for 'head'}}
 
     <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/smallprint.css">
+    <link rel="stylesheet" href="assets/priv-o-matic.css">
     <link href='http://fonts.googleapis.com/css?family=Lato:300,400,300italic' rel='stylesheet' type='text/css'>
     <link href='http://fonts.googleapis.com/css?family=Bitter' rel='stylesheet' type='text/css'>
 

--- a/app/templates/components/step-data-sources.hbs
+++ b/app/templates/components/step-data-sources.hbs
@@ -19,7 +19,7 @@
           {{input type="checkbox" id="otherDataSource" checked=model.statement.otherDataSource}}
           <label for="otherDataSource">Other</label>
             {{#if model.statement.otherDataSource}}
-              {{textarea value=model.statement.otherDataSourceInfo cols="80" rows="6"}}
+              {{textarea value=model.statement.otherDataSourceInfo cols="40" rows="2"}}
             {{/if}}
         </li>
     </ul>
@@ -59,11 +59,12 @@
     {{#modal-message showModal=showNotReadyMessage}}
       <p>You'll need to explain where you get people's personal information from.
         <ul>
-            {{#if model.statement.identityData}}<li>identity</li>{{/if}}
+            {{#if model.statement.identityData}}<li>name</li>{{/if}}
             {{#if model.statement.locationData}}<li>location</li>{{/if}}
-            {{#if model.statement.computerNetworkData}}<li>computer/network</li>{{/if}}
-            {{#if model.statement.userBehaviourData}}<li>behaviour</li>{{/if}}
-            {{#if model.statement.financialData}}<li>finances</li>{{/if}}
+            {{#if model.statement.addressData}}<li>contact information</li>{{/if}}
+            {{#if model.statement.computerNetworkData}}<li>computer/network information</li>{{/if}}
+            {{#if model.statement.userBehaviourData}}<li>how people interact with you</li>{{/if}}
+            {{#if model.statement.financialData}}<li>billing information</li>{{/if}}
             {{#if model.statement.otherDataInfo}}<li>{{model.otherDataInfo}}</li>{{/if}}
         </ul>
       </p>

--- a/app/templates/components/step-statement.hbs
+++ b/app/templates/components/step-statement.hbs
@@ -13,13 +13,13 @@
         <li>
           {{#link-to "steps.step" 9 class="non-link"}}
           {{input type="checkbox" checked=keptSecurely id="keptSecurely"}}
-          <label for="keptSecurely">Reassuring your users their data is kept securely</label>
+          <label for="keptSecurely">Reassuring people that their data is kept securely</label>
           {{/link-to}}
         </li>
         <li>
           {{#link-to "steps.step" 10 class="non-link"}}
             {{input type="checkbox" checked=dataDestruction id="dataDestruction"}}
-            <label for="dataDestruction">Informing your users about data lifetimes and disposal</label>
+            <label for="dataDestruction">Informing people about data lifetimes and disposal</label>
           {{/link-to}}
 
         </li>

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "smallprint",
+  "name": "priv-o-matic",
   "dependencies": {
     "ember": "1.11.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,7 +2,7 @@
 
 module.exports = function(environment) {
   var ENV = {
-    modulePrefix: 'priv-o-matic',
+    modulePrefix: 'smallprint',
     environment: environment,
     baseURL: '/',
     locationType: 'hash',

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,7 +2,7 @@
 
 module.exports = function(environment) {
   var ENV = {
-    modulePrefix: 'smallprint',
+    modulePrefix: 'priv-o-matic',
     environment: environment,
     baseURL: '/',
     locationType: 'hash',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "smallprint",
+  "name": "priv-o-matic",
   "version": "0.0.0",
   "description": "Small description for privstat goes here",
   "private": true,

--- a/tests/index.html
+++ b/tests/index.html
@@ -23,7 +23,7 @@
     {{content-for 'test-body'}}
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>
-    <script src="assets/smallprint.js"></script>
+    <script src="assets/priv-o-matic.js"></script>
     <script src="testem.js"></script>
     <script src="assets/test-loader.js"></script>
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -11,7 +11,7 @@
     {{content-for 'test-head'}}
 
     <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/smallprint.css">
+    <link rel="stylesheet" href="assets/priv-o-matic.css">
     <link rel="stylesheet" href="assets/test-support.css">
 
     {{content-for 'head-footer'}}


### PR DESCRIPTION
Change "smallprint" instances to "priv-o-matic" to avoid modulePrefix conflict.

Change size of "other" blank text box on data source page.

Update data source pop-up when no source entered to match data type edits.