### PR TITLE
fix wording about unique identifiers

### DIFF
--- a/app/templates/components/step-data-types.hbs
+++ b/app/templates/components/step-data-types.hbs
@@ -63,11 +63,14 @@
 
     {{#modal-message showModal=model.statement.uniqueId}}
         <p>
-          You need to be careful collecting these&mdash;you generally can't ask for unique identifiers unless you are the agency that originally assigned it. See 
+          You need to be careful collecting these &mdash; you generally can't use another agency's unique identifier to identify someone. See 
           <a href="https://privacy.org.nz/the-privacy-act-and-codes/privacy-principles/unique-identifiers-principle-twelve/" target="_blank">Privacy Principle 12</a> for more information.
         </p>
         <p>
-          Cases where unique identifiers are collected are a bit too complex for this tool to automatically create you a statement. If this is the case, feel free to <a href="https://privacy.org.nz/contact-us/" target="_blank">contact us</a> for help.
+          If you do collect a unique identifier, you're going to want to specifiy which identifier in the &ldquo;other&rdquo; field below.
+        </p>  
+        <p>
+          Using unique identifiers can be complex &mdash; if you want to discuss how to do it legally, feel free to <a href="https://privacy.org.nz/contact-us/" target="_blank">contact us</a>.
         </p>
     {{/modal-message}}
 


### PR DESCRIPTION
Talked over current wording about unique identifiers - given the number of businesses that might collect these, we didn't want people to hit a wall on the first step.

Unique identifier option is no longer "call us", instead prompts to list unique identifier specifically under "other".