### PR TITLE
Various changes based on external feedback

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -31,7 +31,7 @@ h2 {
   text-align: center;
   font-size: 1.9em;
   font-weight: 400;
-  color: rgb(0, 65, 80);
+  color: rgb(63, 88, 100);
 }
 
 /* Custom checkboxes made out of borders.

--- a/app/templates/components/step-legal-requirement.hbs
+++ b/app/templates/components/step-legal-requirement.hbs
@@ -31,6 +31,7 @@
         <a href="https://privacy.org.nz/collection-of-information-from-subject-principle-three/" target="_blank">Privacy Principle 3</a>
         for more.
       </p>
+      {{yield}}
     {{/modal-message}}
 
   </div>

--- a/app/templates/components/step-sharing.hbs
+++ b/app/templates/components/step-sharing.hbs
@@ -1,6 +1,7 @@
 
 <div class="pure-g">
   <div class="pure-u-3-4">
+
     <p>
       Besides our staff, we share this information with
       <span class="text-input">{{input type="text" value=model.statement.thirdPartySharingNameOne placeholder="a 3rd party" size="13"}}</span>
@@ -21,6 +22,10 @@
 
     <p>
       <button {{action "addParty"}} class="pure-button button-black-on-white button-small">we have another reason for sharing</button>
+    </p>
+   
+    <p>
+      Don't share any of the information you collect? That's fine, move along to the next step.
     </p>
 
     {{yield}}


### PR DESCRIPTION
Changes include
 - new move along button within modal message to allow progress if "yes" checked on legal obligation page
 - change in colour based on new navy blue pantone from OPC comms
- included text for users who don't share personal information with third parties on the sharing page.