### PR TITLE
fixed bug - selecting contact address alone triggered modal in data-types

### DIFF
--- a/app/components/step-data-types.js
+++ b/app/components/step-data-types.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
     Check if our form is filled out
     */
     //if any of this array is true, then we're ready to move forward
-    var options = ['identityData', 'locationData', 'userBehaviourData', 'computerNetworkData', 'financialData', 'otherData'];
+    var options = ['identityData', 'locationData', 'addressData', 'userBehaviourData', 'computerNetworkData', 'financialData', 'otherData'];
     var self = this;
 
     return options.any(function(option) {


### PR DESCRIPTION
addressData wasn't included in the data-types.js check to allow user to move to next step.